### PR TITLE
feat: autoimprove self-improvement setup (dogfooding loop)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "PostToolUse": [
+    "PreToolUse": [
       {
         "matcher": "Edit|Write",
         "hooks": [
@@ -10,13 +10,15 @@
             "blocking": true
           }
         ]
-      },
+      }
+    ],
+    "PostToolUse": [
       {
         "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); f=d.get('file_path',''); sys.exit(0 if 'scripts/' in f else 1)\" && bash test/evaluate/test-evaluate.sh || exit 0"
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | python3 -c \"import sys,json; d=json.load(sys.stdin); f=d.get('file_path',''); sys.exit(0 if 'scripts/' in f else 1)\" && bash test/evaluate/test-evaluate.sh"
           }
         ]
       }

--- a/autoimprove.yaml
+++ b/autoimprove.yaml
@@ -44,6 +44,7 @@ constraints:
     - scripts/evaluate.sh
     - benchmark/**
     - .claude-plugin/**
+    - .claude/**
   test_modification: additive_only
   trust_ratchet:
     tier_0: { max_files: 3, max_lines: 150, mode: auto_merge }

--- a/benchmark/self-metrics.sh
+++ b/benchmark/self-metrics.sh
@@ -4,7 +4,11 @@ DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # test_count: number of test cases in the evaluate.sh test suite
 # Marker format: echo "--- Test: <name> ---"
-test_count=$(grep -c -- "--- Test:" "$DIR/test/evaluate/test-evaluate.sh" 2>/dev/null || echo 0)
+if [ -f "$DIR/test/evaluate/test-evaluate.sh" ]; then
+  test_count=$(grep -c -- "--- Test:" "$DIR/test/evaluate/test-evaluate.sh" 2>/dev/null || true)
+else
+  test_count=0
+fi
 
 # broken_constraints: load-bearing invariant phrases must remain in experimenter agent
 broken_constraints=0
@@ -12,7 +16,11 @@ for phrase in "forbidden_paths" "additive only" "how your changes are scored" "w
   grep -q "$phrase" "$DIR/agents/experimenter.md" 2>/dev/null || broken_constraints=$((broken_constraints + 1)) || true
 done
 # Line-count floor: catches wholesale file gutting
-lines=$(wc -l < "$DIR/agents/experimenter.md" 2>/dev/null || echo 0)
+if [ -f "$DIR/agents/experimenter.md" ]; then
+  lines=$(wc -l < "$DIR/agents/experimenter.md")
+else
+  lines=0
+fi
 [ "$lines" -lt 20 ] && { broken_constraints=$((broken_constraints + 1)) || true; }
 
 # broken_refs: critical files referenced by the orchestrator must exist

--- a/docs/superpowers/plans/2026-03-26-autoimprove-self-improvement.md
+++ b/docs/superpowers/plans/2026-03-26-autoimprove-self-improvement.md
@@ -306,9 +306,7 @@ Expected: `{"test_count": 10, "broken_constraints": 0, "broken_refs": 0}`
 
 Confirm autoimprove.yaml passes YAML parse:
 ```bash
-python3 -c "import json; print('yaml valid - no python yaml, but structure ok')" || true
-# Or if PyYAML available:
-python3 -c "import yaml; yaml.safe_load(open('autoimprove.yaml')); print('yaml valid')" 2>/dev/null || echo "install PyYAML to validate, or proceed"
+python3 -c "import yaml; yaml.safe_load(open('autoimprove.yaml')); print('yaml valid')" 2>/dev/null || echo "install PyYAML to validate: pip install pyyaml"
 ```
 
 Confirm the gate passes:

--- a/docs/superpowers/specs/2026-03-26-autoimprove-on-real-projects-design.md
+++ b/docs/superpowers/specs/2026-03-26-autoimprove-on-real-projects-design.md
@@ -10,7 +10,7 @@ A setup guide for deploying autoimprove on real target projects (lossless-claude
 
 ## Architecture
 
-autoimprove.yaml and benchmark/metrics.sh live in the **target repo**, not in the autoimprove repo. The autoimprove plugin is installed globally; each target project opts in by running `/autoimprove init`.
+autoimprove.yaml and benchmark/metrics.sh live in the **target repo**, not in the autoimprove repo. (Exception: when autoimprove runs on its own codebase for dogfooding/integration validation, autoimprove itself becomes the target repo — see the dogfooding section at the end of this document.) The autoimprove plugin is installed globally; each target project opts in by running `/autoimprove init`.
 
 ```
 target-project/


### PR DESCRIPTION
Adds autoimprove.yaml, benchmark/self-metrics.sh, and .claude/settings.json to enable autoimprove to run on its own codebase.

Primary value: integration validation (confirms a full session completes).
Side effect: grows evaluate.sh test coverage via test_coverage theme.

Metrics: test_count (improvement signal), broken_constraints + broken_refs (safety tripwires).
See: docs/superpowers/specs/2026-03-26-autoimprove-on-real-projects-design.md