### PR TITLE
feat(github): add PR template and Copilot custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# Copilot Review Instructions — autoimprove
+
+This repo implements a self-improvement feedback loop: polling triggers that watch for Claude session output, extract learnings, and write them back as prompts or memory entries.
+
+## Primary concerns
+
+### Trigger idempotency (highest priority)
+- Polling scripts must not process the same event twice. Look for lock files, processed-ID tracking, or state markers.
+- Flag any loop that reads a file/directory and processes entries without marking them as done.
+- `flock` or a `.processed` sentinel file are acceptable patterns.
+
+### Polling interval safety
+- No polling loop should run faster than every 5 minutes. Flag `sleep` values under 300 seconds in recurring loops.
+- Tight retry loops on API failures are a bug — they will exhaust rate limits. Flag `while true; do ... done` without a minimum sleep.
+
+### GitHub API correctness
+- All `gh api` or `curl` calls to GitHub must handle HTTP 429 (rate limited). Look for `x-ratelimit-remaining` checks or exponential backoff.
+- List endpoints return paginated results — flag any code that only reads the first page when completeness matters.
+
+### Prompt quality
+- Flag prompts that use vague instructions: "improve this", "make it better", "do good work". Prompts must be specific about the desired transformation.
+- Prompts should include context about what the input is, what the output format should be, and any constraints.
+
+### Bash 3.2 compatibility (macOS default shell)
+- No `declare -A` associative arrays (bash 4+).
+- No `mapfile` or `readarray` (bash 4+).
+- No `&>>` redirect syntax (bash 4+).
+- No `[[` with `=~` regex and capture groups via `BASH_REMATCH` — test compatibility.
+- Use `#!/usr/bin/env bash` not `#!/bin/bash`.
+
+### Shell safety
+- `set -euo pipefail` at the top of every script.
+- All `$variables` quoted in commands.
+- Temp files use `mktemp` and are cleaned up in a `trap ... EXIT`.
+
+## What to skip
+- Don't flag missing unit tests — integration testing is the norm here.
+- Don't flag `.yaml` indentation unless it's structurally invalid.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- What changed? Be specific — Copilot uses this for review context. -->
+
+## Motivation / Why
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring (no behavior change)
+- [ ] Chore / infra / config
+- [ ] Documentation
+
+## Testing done
+
+<!-- Describe how you tested. Include: did polling trigger correctly? No double-processing? -->
+[NO_TEST_SUITE: autoimprove — integration tested manually]
+
+## Related issues
+
+<!-- Closes #N -->
+
+## Copilot review focus areas
+
+> This repo is a self-improvement loop with polling trigger scripts and prompt engineering.
+> Please pay extra attention to:
+
+- **Trigger idempotency**: Can the same event be processed twice? What prevents double-processing?
+- **Polling safety**: Does the polling loop have a minimum interval? No tight retry loops?
+- **Prompt quality**: Are instructions specific and unambiguous? No vague directives like "do better"?
+- **GitHub API calls**: Are rate limit errors handled? Is pagination handled for list endpoints?
+- **Bash 3.2 compatibility**: No `declare -A` associative arrays, no `mapfile`/`readarray`, no `&>>` append-redirect?
+- **Shell safety**: `set -euo pipefail`? No unquoted variables? Proper quoting of paths?
+- **State files**: Are lock files or state markers cleaned up on exit/failure?
+
+## Checklist
+
+- [ ] `set -euo pipefail` at top of every new shell script
+- [ ] Bash 3.2 compatible (no bash 4+ features)
+- [ ] Polling trigger cannot double-process the same event
+- [ ] GitHub API calls handle 429 rate limit responses
+- [ ] No tight retry loops — minimum 5-minute interval for recurring tasks
+- [ ] Prompt instructions are specific, not vague
+- [ ] Manual test run documented above


### PR DESCRIPTION
Closes part of ipedro/claudinho#32 — structured PR template gives Copilot maximum context for first-round complete review. Copilot instructions define review focus areas per repo.

[SKIP_AR: single additive files, no logic branching]
[NO_TEST_SUITE: autoimprove]