### PR TITLE
fix(trigger): check for Unknown skill before marking run completed

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,20 @@
+# Version Roadmap — autoimprove
+
+## Unreleased
+
+### Added
+- Signal validation guards before write — reject malformed YAML signals (#8, PR #9)
+- xgh metrification — signal collection + autoimprove pipeline (#8, PR #8)
+- AR coverage gate CI workflow (PR #10)
+- Dependabot + CodeQL scanning (PR #11)
+
+### Fixed
+- Python heredoc → env-var passing in autoimprove-trigger.sh (#15, PR #16)
+
+---
+
+## v0.1.0 — (not yet released)
+
+Pre-release. Core trigger pipeline functional. Signal validation, metrics, and CI gates in place.
+
+**Release gate:** adversarial review + Co-CEO greenlight required before first npm/PyPI publish.

--- a/scripts/autoimprove-trigger.sh
+++ b/scripts/autoimprove-trigger.sh
@@ -285,9 +285,14 @@ PYEOF
         log "ERROR $REPO: cannot cd to $LOCAL_PATH"
         exit 0
       }
-      "$CLAUDE_CMD" --print --dangerously-skip-permissions \
-        "/autoimprove run" >> "$LOG_FILE" 2>&1
-      log "DONE $REPO: autoimprove run completed"
+      CLAUDE_OUTPUT=$("$CLAUDE_CMD" --print --dangerously-skip-permissions \
+        "/autoimprove run" 2>&1)
+      echo "$CLAUDE_OUTPUT" >> "$LOG_FILE"
+      if echo "$CLAUDE_OUTPUT" | grep -q "Unknown skill"; then
+        log "ERROR $REPO: autoimprove skill not found — check plugin installation"
+      else
+        log "DONE $REPO: autoimprove run completed"
+      fi
     ) &
   fi
 

--- a/scripts/autoimprove-trigger.sh
+++ b/scripts/autoimprove-trigger.sh
@@ -219,24 +219,27 @@ for REPO in "${REPO_NAMES[@]}"; do
     # Write YAML signal entry consumed by /autoimprove run pipeline
     if [ "$SIGNAL_VALID" = "1" ]; then
       SIGNAL_FILE="${STATE_DIR}/xgh-signal-${LATEST_SHA_SHORT}.yaml"
-      python3 - <<PYEOF
-import yaml, time
+      SIGNAL_FILE_PATH="$SIGNAL_FILE" REPO_NAME="$REPO" MERGE_SHA="$LATEST_SHA" \
+        SPRINT_PR_COUNT_VAL="$SPRINT_PR_COUNT" FINDINGS_VAL="$FINDINGS" \
+        python3 - <<'PYEOF'
+import yaml, time, os
 signal = {
     'source': 'github',
     'project': 'xgh',
-    'repo': '$REPO',
-    'merge_sha': '$LATEST_SHA',
+    'repo': os.environ['REPO_NAME'],
+    'merge_sha': os.environ['MERGE_SHA'],
     'timestamp_iso': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
     'tags': ['project:xgh', 'source:github'],
     'metrics': {
-        'merged_per_sprint': int('$SPRINT_PR_COUNT' or 0),
-        'findings_per_pr': int('$FINDINGS' or 0),
+        'merged_per_sprint': int(os.environ.get('SPRINT_PR_COUNT_VAL') or 0),
+        'findings_per_pr': int(os.environ.get('FINDINGS_VAL') or 0),
         'coverage_delta': None,
     },
 }
-with open('$SIGNAL_FILE', 'w') as f:
+signal_file = os.environ['SIGNAL_FILE_PATH']
+with open(signal_file, 'w') as f:
     yaml.dump(signal, f, default_flow_style=False)
-print('Signal written: $SIGNAL_FILE')
+print(f'Signal written: {signal_file}')
 PYEOF
       log "SIGNAL xgh: metrics written -> $SIGNAL_FILE"
     fi


### PR DESCRIPTION
## Summary
- Captures the output of `claude --print` into a variable instead of piping directly to the log file
- Checks the output for the string `"Unknown skill"` before deciding what to log
- Logs `ERROR <repo>: autoimprove skill not found — check plugin installation` on skill-not-found, skipping the false-positive `DONE` log
- Also updates the deployed copy at `~/.xgh/scripts/autoimprove-trigger.sh`

Closes #18

## Test plan
- [ ] Simulate failure: set `CLAUDE_CMD` to a script that outputs `Unknown skill: autoimprove` — verify `ERROR` is logged and `DONE` is not
- [ ] Simulate success: set `CLAUDE_CMD` to a script that outputs normal text — verify `DONE` is logged
- [ ] Verify the deployed copy at `~/.xgh/scripts/autoimprove-trigger.sh` matches the repo copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)