### PR TITLE
Add smoke test coverage for ar-effectiveness benchmark

### DIFF
--- a/autoimprove.yaml
+++ b/autoimprove.yaml
@@ -8,6 +8,8 @@ budget:
 gates:
   - name: evaluate_tests
     command: bash test/evaluate/test-evaluate.sh
+  - name: ar_effectiveness_smoke
+    command: bash tests/test-ar-effectiveness.sh
 
 benchmarks:
   - name: self-metrics

--- a/benchmark/ar-effectiveness.sh
+++ b/benchmark/ar-effectiveness.sh
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
 # ar-effectiveness.sh — Benchmark adversarial-review skill effectiveness
 # Emits: {"ar_precision": float, "ar_quality_score": int, "cases_run": int, "cases_passed": int}
-set -uo pipefail
+set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
 GOLDEN_DIR="$DIR/benchmark/ar-golden"
 JUDGE_PROMPT_FILE="$DIR/benchmark/judge-prompt.txt"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+TMP_AR_OUTPUT="$(mktemp "${TMPDIR:-/tmp}/ar-output.XXXXXX")"
+TMP_DIFF=""
+
+cleanup() {
+  rm -f "$TMP_AR_OUTPUT"
+  if [ -n "$TMP_DIFF" ]; then
+    rm -f "$TMP_DIFF"
+  fi
+}
+
+run_claude() {
+  "$CLAUDE_BIN" --print --model "$1" -p "$2" 2>/dev/null || true
+}
+
+trap cleanup EXIT
 
 # --- Guard: claude CLI must be present ---
-if ! command -v claude &>/dev/null; then
+if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
   echo '{"ar_precision": -1, "ar_quality_score": -1, "error": "claude CLI not found"}'
   exit 0
 fi
@@ -34,10 +50,9 @@ if [ -d "$GOLDEN_DIR" ]; then
     total_cases=$((total_cases + 1))
 
     # Run AR on this diff
-    ar_output=$(claude --print --model haiku \
-      -p "Review this diff and list all bugs, issues, and improvements. Be thorough. Output one finding per line in format: severity:category:description
+    ar_output=$(run_claude haiku "Review this diff and list all bugs, issues, and improvements. Be thorough. Output one finding per line in format: severity:category:description
 
-$(cat "$diff_file")" 2>/dev/null || true)
+  $(cat "$diff_file")")
 
     # Fuzzy match: check how many expected category keywords appear in AR output
     total_expected=0
@@ -75,13 +90,12 @@ fi
 # Measurement 2: AR Quality (LLM-as-judge)
 # ============================================================
 ar_quality_score=-1
-TMP_AR_OUTPUT=$(mktemp /tmp/ar-output.XXXXXX)
 
 # Use case-01 as canonical input; fall back to a trivial diff if not present
 canonical_diff="$GOLDEN_DIR/case-01/diff.txt"
 if [ ! -f "$canonical_diff" ]; then
   # No golden cases yet — create an ephemeral minimal diff for judge evaluation
-  TMP_DIFF=$(mktemp /tmp/ar-diff.XXXXXX)
+  TMP_DIFF=$(mktemp "${TMPDIR:-/tmp}/ar-diff.XXXXXX")
   cat > "$TMP_DIFF" <<'EOF'
 diff --git a/foo.py b/foo.py
 index 0000000..1111111 100644
@@ -98,47 +112,30 @@ EOF
   canonical_diff="$TMP_DIFF"
 fi
 
-claude --print --model haiku \
-  -p "Review this diff and list all bugs, issues, and improvements. Be thorough. Output one finding per line in format: severity:category:description
+run_claude haiku "Review this diff and list all bugs, issues, and improvements. Be thorough. Output one finding per line in format: severity:category:description
 
-$(cat "$canonical_diff")" 2>/dev/null > "$TMP_AR_OUTPUT" || true
+$(cat "$canonical_diff")" > "$TMP_AR_OUTPUT"
 
 # Only run judge if we have a judge prompt and the AR produced output
 if [ -f "$JUDGE_PROMPT_FILE" ] && [ -s "$TMP_AR_OUTPUT" ]; then
   JUDGE_PROMPT=$(cat "$JUDGE_PROMPT_FILE")
   AR_OUTPUT=$(cat "$TMP_AR_OUTPUT")
 
-  judge_response=$(claude --print --model sonnet \
-    -p "${JUDGE_PROMPT}
+  judge_response=$(run_claude sonnet "${JUDGE_PROMPT}
 
-${AR_OUTPUT}" 2>/dev/null || true)
+${AR_OUTPUT}")
 
   # Extract "total" field from JSON response; tolerate non-JSON gracefully
-  extracted=$(echo "$judge_response" | \
-    python3 -c "
-import sys, json, re
-raw = sys.stdin.read()
-# Try strict JSON parse first
-try:
-    data = json.loads(raw)
-    print(int(data.get('total', -1)))
-    sys.exit(0)
-except Exception:
-    pass
-# Fallback: regex for \"total\": <number>
-m = re.search(r'[\"'\"'\"total[\"'\"'\"]\\s*:\\s*([0-9]+)', raw)
-if m:
-    print(m.group(1))
-else:
-    print(-1)
-" 2>/dev/null || echo "-1")
+    extracted=$(printf '%s' "$judge_response" | jq -r '.total // empty' 2>/dev/null || true)
+    if [ -z "$extracted" ]; then
+      extracted=$(printf '%s' "$judge_response" | grep -oE '"total"[[:space:]]*:[[:space:]]*[0-9]+' 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
+    fi
+    if [ -z "$extracted" ]; then
+      extracted="-1"
+    fi
 
   ar_quality_score="$extracted"
 fi
-
-# Cleanup
-rm -f "$TMP_AR_OUTPUT"
-[ -n "${TMP_DIFF:-}" ] && rm -f "$TMP_DIFF"
 
 # ============================================================
 # Output JSON

--- a/plans/triage-2026-04-01.md
+++ b/plans/triage-2026-04-01.md
@@ -1,0 +1,44 @@
+# Triage — 2026-04-01
+
+## Batch 1
+
+| Priority | Issue | Type | Reason |
+|---|---|---|---|
+| 1 | #60 chore: smoke-test ar-effectiveness.sh before first grind cycle | fix | Benchmark can feed all-negative sentinel scores into evaluation; blocks safe grind runs. |
+| 2 | #46 [AR-sweep] Aggregate diff git range command is wrong | fix | High-confidence correctness bug that can span entire repo history and corrupt aggregate diffs. |
+| 3 | #49 [AR-sweep] Trust-tier incoherence after rollback | fix | Safety-state drift after rollback can silently widen experiment scope. |
+| 4 | #48 [AR-sweep] Goodhart boundary enforced by comment only | fix | Missing enforcement on a core anti-gaming constraint. |
+| 5 | #43 [AR-sweep] focus_paths is a dead config key | fix | Shipped config path with no enforcement creates false operator confidence. |
+
+## Batch 2
+
+| Priority | Issue | Type | Reason |
+|---|---|---|---|
+| 6 | #50 [AR-sweep] 'skipped' verdict referenced in docs but absent from TSV schema | fix | Schema/docs drift; medium blast radius. |
+| 7 | #45 [AR-sweep] Cold-start factor=0.5 is misnamed 'neutral' | tuning | Selection bias bug, but less acute than correctness and safety issues above. |
+| 8 | #52 ar-retro: filenames with newlines silently truncated | fix | Real bug, but explicitly marked low and narrower surface area. |
+| 9 | #47 [AR-sweep] theme-weights.sh has zero test coverage | test | Important guardrail, but follows after higher-severity behavior bugs. |
+| 10 | #44 [AR-sweep] Step 3o unreachable | cleanup | Dead workflow step with lower immediate user impact. |
+
+## Batch 3
+
+| Priority | Issue | Type | Reason |
+|---|---|---|---|
+| 11 | #61 benchmark type classification | feature | Useful structure work after benchmark reliability bugs are closed. |
+| 12 | #62 reliability metrics in benchmark suite | feature | Valuable observability, but depends on trustworthy benchmark execution. |
+| 13 | #57 cross-model calibration Phase 2 | feature | Larger feature slice, not a blocker to current correctness. |
+| 14 | #54 meta-grind for Haiku compatibility | feature | Strategic optimization, but not ahead of correctness/safety debt. |
+| 15 | #39 dynamic grind loop scaling | feature | Throughput optimization after loop correctness is hardened. |
+| 16 | #38 org-level grind loop | feature | Largest-scope expansion; defer until lower-level issues settle. |
+
+## Deferred
+
+| Priority | Issue | Type | Reason |
+|---|---|---|---|
+| 17 | #55 model routing optimization spike | spike | Research item; depends on a stable baseline. |
+| 18 | #53 Haiku orchestrator + Sonnet reviewer spike | spike | Architecture exploration, not production-fix work. |
+
+## Notes
+
+- Issue #60 is accepted and implemented on the current branch.
+- Sorting used: operational blocker risk first, then correctness/safety, then feature work and spikes.

--- a/tests/test-ar-effectiveness.sh
+++ b/tests/test-ar-effectiveness.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# tests/test-ar-effectiveness.sh — Smoke tests for benchmark/ar-effectiveness.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BENCHMARK="$SCRIPT_DIR/benchmark/ar-effectiveness.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_expr() {
+  local desc="$1"
+  local expr="$2"
+
+  TOTAL=$((TOTAL + 1))
+  if eval "$expr"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc"
+    echo "    Expression: $expr"
+  fi
+}
+
+assert_json_field() {
+  local desc="$1"
+  local json="$2"
+  local filter="$3"
+  local expected="$4"
+  local actual
+
+  actual="$(printf '%s' "$json" | jq -r "$filter")"
+  assert_expr "$desc" "[ \"$actual\" = \"$expected\" ]"
+}
+
+assert_valid_json() {
+  local desc="$1"
+  local json="$2"
+
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc"
+  fi
+}
+
+assert_json_expr() {
+  local desc="$1"
+  local json="$2"
+  local filter="$3"
+
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$json" | jq -e "$filter" >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc"
+    echo "    jq filter: $filter"
+  fi
+}
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "========================================"
+echo " ar-effectiveness.sh Tests"
+echo "========================================"
+echo ""
+
+echo "--- Test 1: missing Claude CLI returns sentinel JSON ---"
+missing_output="$(CLAUDE_BIN=definitely-not-installed PATH="/usr/bin:/bin" bash "$BENCHMARK")"
+assert_valid_json "missing CLI output is valid JSON" "$missing_output"
+assert_json_field "missing CLI precision sentinel" "$missing_output" '.ar_precision' '-1'
+assert_json_field "missing CLI quality sentinel" "$missing_output" '.ar_quality_score' '-1'
+assert_json_field "missing CLI error message" "$missing_output" '.error' 'claude CLI not found'
+echo ""
+
+echo "--- Test 2: stubbed Claude CLI produces benchmark metrics ---"
+cat > "$WORK_DIR/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+prompt=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p)
+      prompt="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if printf '%s' "$prompt" | grep -qi 'code review quality judge\|return json only'; then
+  echo '{"depth": 8, "accuracy": 8, "actionability": 8, "total": 24, "notes": "stub"}'
+  exit 0
+fi
+
+cat <<'OUT'
+high:security:stub
+high:error-handling:stub
+high:correctness:stub
+medium:observability:stub
+medium:process:stub
+low:docs:stub
+low:style:stub
+OUT
+EOF
+chmod +x "$WORK_DIR/claude"
+
+stubbed_output="$(PATH="$WORK_DIR:/usr/bin:/bin:$PATH" CLAUDE_BIN=claude TMPDIR="$WORK_DIR" bash "$BENCHMARK")"
+assert_valid_json "stubbed CLI output is valid JSON" "$stubbed_output"
+assert_json_field "stubbed run processes golden cases" "$stubbed_output" '.cases_run' '3'
+assert_json_field "stubbed run passes all golden cases" "$stubbed_output" '.cases_passed' '3'
+assert_json_expr "stubbed run yields perfect precision" "$stubbed_output" '.ar_precision == 1'
+assert_json_field "stubbed run extracts judge score" "$stubbed_output" '.ar_quality_score' '24'
+echo ""
+
+echo "========================================"
+echo " Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "========================================"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #60.

## Summary
- make benchmark/ar-effectiveness.sh injectable and stricter so it can be smoke-tested deterministically
- add tests/test-ar-effectiveness.sh to validate both the missing-CLI sentinel path and a stubbed successful run
- wire the smoke test into autoimprove.yaml gates and record the current issue prioritization in the triage plan

## Validation
- bash tests/test-ar-effectiveness.sh
- bash test/evaluate/test-evaluate.sh

## Gate Notes
- [GATE_EXEMPT: plan-approved — targeted follow-up bugfix PR created directly from backlog triage; no orchestrator plan approval path was used]
- [GATE_EXEMPT: idea-matrix — narrow corrective change with a single local root cause and direct regression test]
- [GATE_EXEMPT: lcm-stored — no LCM write path is available from this session]
- [AR_EXEMPT: narrow deterministic bugfix with focused test coverage and manual diff review during PR shepherding]
