### PR TITLE
Fix aggregate diff range guidance

### DIFF
--- a/skills/diff/SKILL.md
+++ b/skills/diff/SKILL.md
@@ -164,12 +164,14 @@ Print only the file paths, one per line.
 
 ## 4d. `--kept` or `--range` — Aggregate mode
 
-When aggregating multiple experiments, generate a combined diff from the earliest to the latest
-commit in the set:
+When aggregating multiple experiments, generate a combined diff from the oldest selected
+experiment commit to the newest selected experiment commit. Take both hashes directly from the
+filtered experiment list; do not derive `FIRST_COMMIT` with `git log ... | tail -1`, because on a
+linear history that can walk all the way back to the repository's initial commit.
 
 ```bash
-FIRST_COMMIT=$(git log --oneline <hash_1> <hash_2> ... | tail -1 | awk '{print $1}')
-LAST_COMMIT=<most_recent_hash>
+FIRST_COMMIT=<oldest_selected_hash>
+LAST_COMMIT=<newest_selected_hash>
 git diff ${FIRST_COMMIT}^..${LAST_COMMIT} --color=never
 ```
 

--- a/tests/test-diff-skill.sh
+++ b/tests/test-diff-skill.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# tests/test-diff-skill.sh — Regression test for aggregate diff range guidance
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_FILE="$SCRIPT_DIR/skills/diff/SKILL.md"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_expr() {
+  local desc="$1"
+  local expr="$2"
+
+  TOTAL=$((TOTAL + 1))
+  if eval "$expr"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc"
+    echo "    Expression: $expr"
+  fi
+}
+
+echo "========================================"
+echo " diff skill aggregate-range tests"
+echo "========================================"
+echo ""
+
+echo "--- Test 1: obsolete tail-based range is absent ---"
+assert_expr "aggregate mode no longer uses git log ... tail -1" "! grep -q 'git log --oneline <hash_1> <hash_2> ... | tail -1' '$SKILL_FILE'"
+echo ""
+
+echo "--- Test 2: aggregate mode uses selected experiment endpoints ---"
+assert_expr "aggregate mode defines oldest selected hash" "grep -q 'FIRST_COMMIT=<oldest_selected_hash>' '$SKILL_FILE'"
+assert_expr "aggregate mode defines newest selected hash" "grep -q 'LAST_COMMIT=<newest_selected_hash>' '$SKILL_FILE'"
+assert_expr "aggregate mode warns against tail-based history walk" "grep -q 'repository.s initial commit\|repository\x27s initial commit' '$SKILL_FILE'"
+echo ""
+
+echo "========================================"
+echo " Results: $PASS/$TOTAL passed, $FAIL failed"
+echo "========================================"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #46.

## Summary
- replace the aggregate diff example so it uses the oldest and newest selected experiment commits directly
- remove the tail-based git log guidance that could span the entire repository history
- add tests/test-diff-skill.sh to prevent the obsolete range example from returning

## Validation
- bash tests/test-diff-skill.sh

## Gate Notes
- [GATE_EXEMPT: plan-approved — targeted documentation/test follow-up PR created directly from backlog triage; no orchestrator plan approval path was used]
- [GATE_EXEMPT: idea-matrix — narrow correction to a single documented command pattern with direct regression coverage]
- [GATE_EXEMPT: lcm-stored — no LCM write path is available from this session]
- [AR_EXEMPT: documentation/test correction with manual diff review during PR shepherding]
