### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Something isn't working
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "P0 — production broken"
+        - "P1 — blocks current sprint"
+        - "P2 — degraded but functional"
+        - "P3 — cosmetic / low impact"
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, environment details

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: LCM Decision
+    url: https://github.com/ipedro/claudinho/issues
+    about: For LCM-tracked decisions, use the claudinho repo

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,26 @@
+name: Enhancement
+description: New feature or improvement to existing functionality
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What pain point does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: dropdown
+    id: effort
+    attributes:
+      label: Estimated effort
+      options: [XS, S, M, L, XL]
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/ISSUE_TEMPLATE/introspection.yml
+++ b/.github/ISSUE_TEMPLATE/introspection.yml
@@ -1,0 +1,30 @@
+name: Introspection Finding
+description: Actionable finding from agent self-evaluation
+labels: [introspection]
+body:
+  - type: input
+    id: agent
+    attributes:
+      label: Agent/model that produced this
+    validations:
+      required: true
+  - type: textarea
+    id: finding
+    attributes:
+      label: Finding
+    validations:
+      required: true
+  - type: textarea
+    id: action
+    attributes:
+      label: Proposed action
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Impact
+      options:
+        - "High — affects core workflows"
+        - "Medium — affects efficiency"
+        - "Low — nice to have"

--- a/.github/ISSUE_TEMPLATE/research.yml
+++ b/.github/ISSUE_TEMPLATE/research.yml
@@ -1,0 +1,22 @@
+name: Research / Scout
+description: Investigation, spike, or external research
+labels: [research]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Research question
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and constraints
+  - type: dropdown
+    id: timebox
+    attributes:
+      label: Timeboxed to
+      options:
+        - 15 min (quick lookup)
+        - 1 hour (spike)
+        - Half sprint (deep dive)

--- a/.github/ISSUE_TEMPLATE/skill-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/skill-proposal.yml
@@ -1,0 +1,28 @@
+name: Skill Proposal
+description: Propose a new reusable skill for the org
+labels: [skill-proposal]
+body:
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill name
+    validations:
+      required: true
+  - type: textarea
+    id: trigger
+    attributes:
+      label: Trigger conditions
+      description: When should this skill activate?
+    validations:
+      required: true
+  - type: textarea
+    id: automation
+    attributes:
+      label: What it automates
+    validations:
+      required: true
+  - type: textarea
+    id: token-savings
+    attributes:
+      label: Estimated token savings
+      description: Rough estimate of tokens saved per invocation


### PR DESCRIPTION
Add standardized issue templates (bug-report, enhancement, skill-proposal, research, introspection) and config.yml.

Part of GitHub Pro migration (ipedro/claudinho#237).