### PR TITLE
docs: add security runbook and sprint guide

### DIFF
--- a/.github/SECURITY_RUNBOOK.md
+++ b/.github/SECURITY_RUNBOOK.md
@@ -1,0 +1,40 @@
+# Security Runbook
+
+## Secret Exposure Response
+
+1. **Revoke** the exposed secret immediately
+2. **Rotate** any derived credentials
+3. **Search** git history for other instances: `git log -p --all -S 'secret_pattern'`
+4. **Notify** Co-CEOs via Telegram
+5. **Create** a post-mortem issue with label `p0-critical`
+
+## Secret Scanning
+
+- GitHub secret scanning is enabled on this repo
+- Push protection blocks pushes containing known secret patterns
+- Custom patterns configured via gitleaks (lcm repo)
+
+## Branch Protection
+
+- `main` branch is protected — PRs required
+- Status checks must pass: ar-coverage, quality-gates
+- Force push is disabled
+- Branch deletion is disabled
+
+## Dependency Management
+
+- Dependabot security updates are enabled
+- Review and merge dependency PRs promptly
+- CodeQL analysis runs on all PRs
+
+## Incident Escalation
+
+| Severity | Response Time | Channel |
+|----------|--------------|---------|
+| P0 — credentials exposed | Immediate | Telegram + issue |
+| P1 — vulnerability found | Same day | GitHub issue |
+| P2 — dependency update | Next sprint | PR review |
+
+## Contacts
+
+- Pedro Almeida (@ipedro) — org owner, final authority

--- a/.github/SPRINT_GUIDE.md
+++ b/.github/SPRINT_GUIDE.md
@@ -1,0 +1,54 @@
+# Sprint Guide
+
+## Sprint Cadence
+
+- **Sprint = 1 day** (aligned to Anthropic token budget daily reset)
+- **Milestone = 1 week** (Tuesday to Monday, ISO week numbering: W2026-NN)
+- **Ceremony:** End of each weekly milestone
+
+## Milestone Naming
+
+Format: `W2026-NN` where NN is the ISO week number.
+
+## Sprint Workflow
+
+### Daily
+1. `/standup` — review yesterday, plan today
+2. Work items from project board (highest priority first)
+3. PRs follow quality gates: ar-coverage, quality-gates
+4. End of day: `/introspection` for all agents
+
+### Weekly Ceremony
+1. Close current milestone
+2. Move unfinished items to next milestone
+3. Create retrospective issue (label: `post-mortem`)
+4. Review velocity metrics
+5. Create next week's milestones across all repos
+6. Triage `introspection` issues
+
+## Labels
+
+### Priority (mutually exclusive)
+- `p0-critical` — production broken, immediate
+- `p1-high` — current sprint, blocks delivery
+- `p2-medium` — next sprint
+- `p3-low` — backlog
+
+### Type (mutually exclusive)
+- `bug` — something broken
+- `enhancement` — new feature or improvement
+- `chore` — maintenance, CI, config
+- `research` — spike, investigation
+- `skill-proposal` — new skill for the org
+
+## Project Board
+
+All work tracked on [Org Operations v2](https://github.com/users/ipedro/projects/5).
+
+Views:
+1. **Sprint Board** — current sprint kanban
+2. **Triage** — unprocessed items
+3. **Roadmap** — timeline view
+4. **By Product** — per-repo focus
+5. **Backlog** — prioritized backlog
+6. **Done/Archive** — completed work


### PR DESCRIPTION
Add .github/SECURITY_RUNBOOK.md and .github/SPRINT_GUIDE.md.

Part of GitHub Pro migration (ipedro/claudinho#237).